### PR TITLE
Double Supplier Update

### DIFF
--- a/src/main/java/org/team5924/frc2026/subsystems/rollers/exampleRoller/ExampleRoller.java
+++ b/src/main/java/org/team5924/frc2026/subsystems/rollers/exampleRoller/ExampleRoller.java
@@ -18,6 +18,9 @@ package org.team5924.frc2026.subsystems.rollers.exampleRoller;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import java.util.function.DoubleSupplier;
+
 import org.team5924.frc2026.RobotState;
 import org.team5924.frc2026.subsystems.rollers.generic.GenericRollerSystem;
 import org.team5924.frc2026.subsystems.rollers.generic.GenericRollerSystem.VoltageState;
@@ -33,11 +36,11 @@ public class ExampleRoller
   @RequiredArgsConstructor
   @Getter
   public enum ExampleRollerState implements VoltageState {
-    IDLE(new LoggedTunableNumber("ExampleRoller/Idle", 0.0)),
+    IDLE(() -> 0.0),
     SHOOTING(new LoggedTunableNumber("ExampleRoller/Shooting", 12.0)),
     INTAKE(new LoggedTunableNumber("ExampleRoller/Intake", -12.0));
 
-    private final LoggedTunableNumber voltageSupplier;
+    private final DoubleSupplier voltageSupplier;
   }
 
   private ExampleRollerState goalState = ExampleRollerState.IDLE;

--- a/src/main/java/org/team5924/frc2026/subsystems/rollers/generic/GenericRollerSystem.java
+++ b/src/main/java/org/team5924/frc2026/subsystems/rollers/generic/GenericRollerSystem.java
@@ -20,13 +20,15 @@ import edu.wpi.first.wpilibj.Alert;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import lombok.RequiredArgsConstructor;
+
+import java.util.function.DoubleSupplier;
+
 import org.littletonrobotics.junction.Logger;
 import org.littletonrobotics.junction.inputs.LoggableInputs;
 import org.team5924.frc2026.subsystems.rollers.generic.GenericRollerSystemIO.GenericRollerSystemIOInputs;
 import org.team5924.frc2026.util.Elastic;
 import org.team5924.frc2026.util.Elastic.Notification;
 import org.team5924.frc2026.util.Elastic.Notification.NotificationLevel;
-import org.team5924.frc2026.util.LoggedTunableNumber;
 
 @RequiredArgsConstructor
 public abstract class GenericRollerSystem<
@@ -36,9 +38,9 @@ public abstract class GenericRollerSystem<
         InputsAutoLogged extends Inputs>
     extends SubsystemBase {
   public interface VoltageState {
-    LoggedTunableNumber getVoltageSupplier();
+    DoubleSupplier getVoltageSupplier();
 
-    default LoggedTunableNumber getHandoffVoltage() {
+    default DoubleSupplier getHandoffVoltage() {
       return getVoltageSupplier();
     }
   }


### PR DESCRIPTION
update to use DoubleSupplier instead of LoggedTunableNumber in generic/example roller system states